### PR TITLE
Fix NPE in JobStore when jobs.xml is empty.

### DIFF
--- a/services/core/java/com/android/server/job/JobStore.java
+++ b/services/core/java/com/android/server/job/JobStore.java
@@ -457,7 +457,7 @@ public class JobStore {
             while (eventType != XmlPullParser.START_TAG &&
                     eventType != XmlPullParser.END_DOCUMENT) {
                 eventType = parser.next();
-                Slog.d(TAG, parser.getName());
+                Slog.d(TAG, "Start tag: " + parser.getName());
             }
             if (eventType == XmlPullParser.END_DOCUMENT) {
                 if (DEBUG) {


### PR DESCRIPTION
It is possible that jobs.xml does not have valid content
if the device meet unexpected power off or reboot during
writing the file, then parser.getName() may get null string
on next boot.

Because log does not allow to print null message.
It will result boot fail:
Caused by: java.lang.NullPointerException: println needs a message
 at android.util.Log.println_native(Native Method)
 at android.util.Slog.d
 at com.android.server.job.JobStore
    $ReadJobMapFromDiskRunnable.readJobMapImpl

Change-Id: Icd485096e2f00f4028428a9ad95cd0ef66b2dca0